### PR TITLE
implement own drag'n drop (YAVDnD) and integrate it to InventoryGrid, InventoryGridCell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@formkit/drag-and-drop": "^0.1.6",
+        "@vueuse/core": "^10.11.1",
         "pinia": "^2.1.7",
         "vue": "^3.4.29"
       },
@@ -1075,6 +1076,11 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -1478,6 +1484,89 @@
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
       "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
       "dev": true
+    },
+    "node_modules/@vueuse/core": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.11.1",
+        "@vueuse/shared": "10.11.1",
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
+      "dependencies": {
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "rlt-inventory",
       "version": "0.0.0",
       "dependencies": {
-        "@formkit/drag-and-drop": "^0.1.6",
         "@vueuse/core": "^10.11.1",
         "pinia": "^2.1.7",
         "vue": "^3.4.29"
@@ -726,11 +725,6 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/@formkit/drag-and-drop": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@formkit/drag-and-drop/-/drag-and-drop-0.1.6.tgz",
-      "integrity": "sha512-wZyxvk7WTbQ12q8ZGvLoYner1ktBOUf+lCblJT3P0LyqpjGCKTfQMKJtwToKQzJgTbhvow4LBu+yP92Mux321w=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "stylelint-fix": "stylelint \"./src/**/*.{css,scss,sass,vue}\" --fix"
   },
   "dependencies": {
-    "@formkit/drag-and-drop": "^0.1.6",
     "@vueuse/core": "^10.11.1",
     "pinia": "^2.1.7",
     "vue": "^3.4.29"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@formkit/drag-and-drop": "^0.1.6",
+    "@vueuse/core": "^10.11.1",
     "pinia": "^2.1.7",
     "vue": "^3.4.29"
   },

--- a/src/assets/scss/_cards.scss
+++ b/src/assets/scss/_cards.scss
@@ -58,6 +58,7 @@
 
     border: none;
     border-radius: 0;
+    user-select: none;
 
     &:hover {
       background-color: var(--theme-color-background-card-hover);
@@ -65,6 +66,15 @@
 
     &.selected {
       background-color: var(--theme-color-background-card-selected);
+    }
+
+    &.dragging {
+      border-radius: 24px;
+      box-shadow: 0 0 36px #fff4;
+
+      .item .count {
+        display: none;
+      }
     }
 
     &.dropzone {
@@ -78,6 +88,7 @@
       font-size: 18px;
       height: 100%;
       justify-content: center;
+      pointer-events: none;
       position: relative;
       width: 100%;
 

--- a/src/components/InventoryGrid.vue
+++ b/src/components/InventoryGrid.vue
@@ -27,16 +27,14 @@ for (let i = 0; i < 25; i++) {
   cells.value.push(obj);
 }
 
-/* Cell selection */
+/* Cell actions */
 const selectedCell = ref<GridCell | null>();
-
 function selectCell(cell: GridCell) {
   if (cell.item === null) return;
 
   selectedCell.value = cell;
 }
 
-/* Cell actions */
 function deleteItemInCell(cell: GridCell, count: number) {
   const cellToDelete = cells.value.find((c) => cell === c);
 
@@ -59,6 +57,14 @@ function deleteItemInCell(cell: GridCell, count: number) {
         :key="cell.id"
         :cell
         :class="{ selected: selectedCell === cell }"
+        :draggable="{
+          handleDragStart: (draggable) => {
+            const isCellEmpty = draggable.item.value.item == null;
+            if(isCellEmpty) return false;
+            
+            selectedCell = null;
+          },
+        }"
         @click="selectCell(cell)"
       />
     </div>

--- a/src/components/InventoryGrid.vue
+++ b/src/components/InventoryGrid.vue
@@ -1,24 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { swap } from '@formkit/drag-and-drop';
-import { useDragAndDrop } from '@formkit/drag-and-drop/vue';
 import InventoryGridCell from './InventoryGridCell.vue';
 import InventoryGridItemDetailsModal from './InventoryGridItemDetailsModal.vue';
-import { usePreventDrag } from '@/composable/usePreventDrag';
 import type { GridCell } from '@/types/inventory/grid-cell';
 
-/* Init Drag'n Drop behavior */
-const [cellsRef, cells] = useDragAndDrop<GridCell>([], {
-  // Prevent drag if cell hasn't any item
-  ...usePreventDrag((targetData) => targetData.node.data.value?.item === null),
+/* Init and fill cells with placeholder data */
+const cells = ref<GridCell[]>([]);
 
-  dropZoneClass: 'dropzone',
-  touchDropZoneClass: 'dropzone',
-
-  plugins: [swap()],
-});
-
-/* Fill cells with placeholder data */
 for (let i = 0; i < 25; i++) {
   let obj: GridCell = {
     id: i,
@@ -65,7 +53,7 @@ function deleteItemInCell(cell: GridCell, count: number) {
 
 <template>
   <div class="inventory-grid-card">
-    <div ref="cellsRef" class="cells">
+    <div class="cells">
       <InventoryGridCell
         v-for="cell in cells"
         :key="cell.id"

--- a/src/components/InventoryGridCell.vue
+++ b/src/components/InventoryGridCell.vue
@@ -17,6 +17,11 @@ const props = defineProps<{
   dropzone?: DropzoneEventHandlers<GridCell>;
 }>();
 
+const image = computed(() => {
+  if (!props.cell.item) return '';
+  return inventoryItemDetailStore.getImageByCode(props.cell.item.code)
+});
+
 const [initDrag, draggable] = useDrag<GridCell>({
   type: 'inventory-grid-cell',
   item: props.cell,
@@ -43,7 +48,7 @@ const [initDrop, dropzone] = useDrop({
     class="inventory-grid-cell-card"
   >
     <div class="item" v-if="cell?.item">
-      <img class="image" :src="inventoryItemDetailStore.getImageByCode(cell.item.code)" />
+      <img class="image" :src="image" />
 
       <div class="count">
         {{ cell.item.count }}

--- a/src/components/InventoryGridCell.vue
+++ b/src/components/InventoryGridCell.vue
@@ -1,17 +1,47 @@
 <script setup lang="ts">
-import type { PropType } from 'vue';
+import { computed } from 'vue';
+
+import { useDrag } from '@/composable/drag-and-drop/useDrag';
+import { useDrop, type DropzoneEventHandlers } from '@/composable/drag-and-drop/useDrop';
+import type { Draggable } from '@/composable/drag-and-drop/useDrag';
+
 import type { GridCell } from '@/types/inventory/grid-cell';
 import { useInventoryItemDetailStore } from '@/stores/inventoryItemDetail';
+import type { DraggableEventHandlers } from '@/composable/drag-and-drop/useDrag';
 
 const inventoryItemDetailStore = useInventoryItemDetailStore();
 
-defineProps({
-  cell: Object as PropType<GridCell>,
+const props = defineProps<{
+  cell: GridCell;
+  draggable?: DraggableEventHandlers<GridCell>;
+  dropzone?: DropzoneEventHandlers<GridCell>;
+}>();
+
+const [initDrag, draggable] = useDrag<GridCell>({
+  type: 'inventory-grid-cell',
+  item: props.cell,
+
+  draggingCloneClass: 'dragging',
+
+  onDragStart: (draggable) => props.draggable?.handleDragStart?.(draggable),
+  onSuccessfulDrop: (draggable) => props.draggable?.handleSuccessfulDrop?.(draggable),
+});
+
+const [initDrop, dropzone] = useDrop({
+  accepts: 'inventory-grid-cell',
+  dropZoneClass: 'dropzone',
+
+  onSuccessfulDrop(draggable: Draggable<GridCell>) {
+    [props.cell.item, draggable.item.value.item] = [draggable.item.value.item, props.cell.item];
+  },
 });
 </script>
 
 <template>
-  <div class="inventory-grid-cell-card">
+  <div
+    :ref="(node) => initDrop(initDrag(node))"
+    class="inventory-grid-cell-card"
+  >
     <div class="item" v-if="cell?.item">
       <img class="image" :src="inventoryItemDetailStore.getImageByCode(cell.item.code)" />
 

--- a/src/composable/drag-and-drop/README.md
+++ b/src/composable/drag-and-drop/README.md
@@ -1,0 +1,166 @@
+# Yet Another Vue Drag-and-Drop (YAVDnD) 
+
+## Description
+Drag and Drop implementation without relying on horrible native HTML
+
+It consist of three composables:
+  - **useDrag** / **useDrop** - provides to any HTML element drag / drop functionality. Can be used together
+  - **useDragAndDropState** - tracks **Draggables** and **Dropzones** created with the previous composables 
+
+## How to use
+
+  1. Import **useDrag** / **useDrop** 
+  2. Provide required options (**type**, **item**) and get [**initDrag**, **draggable**] / [**initDrop**, **dropzone**] 
+  3. Use **initDrag** / **initDrop** as a HTML element's **:ref**
+
+```
+<script setup lang="ts">
+...
+
+const props = defineProps<{
+  cell: GridCell;
+  draggable?: DraggableEventHandlers<GridCell>;
+  dropzone?: DropzoneEventHandlers<GridCell>;
+}>();
+
+const [initDrag, draggable] = useDrag<GridCell>({
+  type: 'card',
+  item: props.cell,
+
+  draggingCloneClass: 'dragging',
+
+  onDragStart: (draggable) => props.draggable?.handleDragStart?.(draggable),
+  onSuccessfulDrop: (draggable) => props.draggable?.handleSuccessfulDrop?.(draggable),
+});
+</script>
+
+<template>
+  <div :ref="initDrag"></div>
+</template>
+```
+
+### Warning
+It can be used only on HTML element, not nested Vue component:
+
+**Good**
+```
+<div :ref="initDrag"></div>
+```
+
+**Bad**
+```
+<MyComponent :ref="initDrag"/>
+```
+
+### Drag + Drop
+
+1. Use **useDrag** + **useDrop**
+2. Wrap **initDrag** within **initDrop** in a HTML element's **:ref**
+
+```
+<script setup lang="ts">
+...
+
+const props = defineProps<{
+  cell: GridCell;
+  draggable?: DraggableEventHandlers<GridCell>;
+  dropzone?: DropzoneEventHandlers<GridCell>;
+}>();
+
+const [initDrag, draggable] = useDrag<GridCell>({
+  type: 'card',
+  item: props.cell,
+
+  draggingCloneClass: 'dragging',
+
+  onDragStart: (draggable) => props.draggable?.handleDragStart?.(draggable),
+  onSuccessfulDrop: (draggable) => props.draggable?.handleSuccessfulDrop?.(draggable),
+});
+
+const [initDrop, dropzone] = useDrop({
+  accepts: 'card',
+  dropZoneClass: 'dropzone',
+
+  onSuccessfulDrop(draggable: Draggable<GridCell>) {
+    [props.cell.item, draggable.item.value.item] = [draggable.item.value.item, props.cell.item];
+  },
+});
+</script>
+
+<template>
+  <div :ref="(node) => initDrop(initDrag(node))"></div>
+</template>
+```
+
+### Customization
+
+You can customize **useDrag** / **useDrop**  behaviour with it options. 
+Check **DragOptions** type definition: 
+```
+...
+  /**
+   * Type of the draggable
+   */
+  type: string;
+
+  /**
+   * The reactive reference holding the value of the draggable
+   */
+  item: MaybeRef<T>;
+
+  /**
+   * Optional delay before the drag operation starts, in milliseconds
+   */
+  startDelay?: number;
+
+  /**
+   * Optional class name to be added to the draggable element while it is being dragged
+   */
+  draggingClass?: string;
+
+  /**
+   * Optional class name to be added to the draggable cloned element while it is being dragged
+   */
+  draggingCloneClass?: string;
+...
+```
+
+and **DropOptions** :
+```
+...
+  /**
+   * What type of draggable should be allowed to drop in the dropzone
+   */
+  accepts: string;
+
+  /**
+   * Optional class name to be added to the dropzone element while any valid draggable is over the dropzone
+   */
+  dropZoneClass?: string;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was made
+   * @param draggable - The draggable state that tries to drop to a dropzone
+   * @returns
+   */
+  onDropAttempt?: (draggable: Draggable<any>) => void;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was failed
+   * @param draggable - The draggable state that failed to drop to a dropzone
+   * @returns
+   */
+  onFailedDrop?: (draggable: Draggable<any>) => void;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was successful
+   * @param draggable - The draggable state that dropped to a dropzone
+   * @returns
+   */
+  onSuccessfulDrop?: (draggable: Draggable<any>) => void;
+...
+```
+
+## Fin
+
+Made by **zerescas**

--- a/src/composable/drag-and-drop/useDrag.ts
+++ b/src/composable/drag-and-drop/useDrag.ts
@@ -166,7 +166,7 @@ export const useDrag = <T>(
   let dragLongPressTimer: number | undefined = 0;
 
   /* Watch for mouse press state changes to start or end drag */
-  watch(pressed, (_pressed) => (_pressed ? startDrag() : endDrag()));
+  watch(pressed, (_pressed) => (_pressed ? setTimeout(() => startDrag(), 0) : endDrag()));
 
   /**
    * Start the drag operation

--- a/src/composable/drag-and-drop/useDrag.ts
+++ b/src/composable/drag-and-drop/useDrag.ts
@@ -1,0 +1,294 @@
+import { onMounted, onUnmounted, ref, toRef, watch, type MaybeRef, type Ref } from 'vue';
+import { useMouse, useMousePressed } from '@vueuse/core';
+
+import { useDragAndDropState } from './useDragAndDropState';
+import type { Vector2D } from '@/types/vector-2d';
+import type { Dropzone } from './useDrop';
+
+/**
+ * Draggable state
+ */
+export interface Draggable<T> {
+  /**
+   * A type of Draggable
+   */
+  type: string;
+
+  /**
+   * The reactive reference holding the element of the draggable
+   */
+  element: Ref<HTMLElement | null | undefined>;
+
+  /**
+   * The reactive reference holding the dropzone where the draggable located now
+   */
+  enteredDropzone: Ref<Dropzone | null | undefined>;
+
+  /**
+   * The reactive reference holding the value of the draggable
+   */
+  item: Ref<T>;
+
+  /**
+   * Is draggable it dragging state
+   */
+  isDragging: Ref<boolean>;
+}
+
+interface DragOptions<T> {
+  /**
+   * Type of the draggable
+   */
+  type: string;
+
+  /**
+   * The reactive reference holding the value of the draggable
+   */
+  item: MaybeRef<T>;
+
+  /**
+   * Optional delay before the drag operation starts, in milliseconds
+   */
+  startDelay?: number;
+
+  /**
+   * Optional class name to be added to the draggable element while it is being dragged
+   */
+  draggingClass?: string;
+
+  /**
+   * Optional class name to be added to the draggable cloned element while it is being dragged
+   */
+  draggingCloneClass?: string;
+
+  /**
+   * Optional callback function that is triggered when the drag operation starts
+   * @param draggable - The draggable state that starting drag operation
+   * @returns Optionally return false to prevent the default drag behavior
+   */
+  onDragStart?: (draggable: Draggable<T>) => void | boolean;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was made
+   * @param draggable - The draggable state that tries to drop to a dropzone
+   * @returns
+   */
+  onDropAttempt?: (draggable: Draggable<T>) => void;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was failed
+   * @param draggable - The draggable state that failed to drop to a dropzone
+   * @returns
+   */
+  onFailedDrop?: (draggable: Draggable<T>) => void;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was successful
+   * @param draggable - The draggable state that dropped to a dropzone
+   * @returns
+   */
+  onSuccessfulDrop?: (draggable: Draggable<T>) => void;
+}
+
+interface DragReturn<T> {
+  /**
+   * Function to be used with an HTML element's `ref` attribute to give the element drag functionality
+   * @example
+   * const [initDrag, draggable] = useDrag<Item>({...})
+   * <div :ref="initDrag"></div>
+   *
+   * @param el - The HTML element that should have drag functionality applied
+   *
+   * @returns The same HTML element. It useful if you want to give the element drag/drop functionality simultaneously
+   * @example
+   * const [initDrag, draggable] = useDrag<Item>({...})
+   * const [initDrop, dropzone] = useDrop<Item>({...})
+   * <div :ref="(node) => initDrop(initDrag(node))"></div>
+   */
+  init: (el: any) => {};
+
+  /**
+   * The state of the created draggable in `useDrag` composable
+   */
+  draggable: Draggable<T>;
+}
+
+/**
+ * Handlers to use in defineProps' types
+ * @example
+ * const props = defineProps<{
+ *   cell: GridCell;
+ *   draggable?: DraggableEventHandlers<GridCell>;
+ * }>();
+ * 
+ * ...
+ * props.draggable?.handleDragStart?.(draggable);
+ * ...
+ */
+export interface DraggableEventHandlers<T> {
+  handleDragStart?: (draggable: Draggable<T>) => boolean | void;
+  handleDropAttempt?: (draggable: Draggable<T>) => void;
+  handleFailedDrop?: (draggable: Draggable<T>) => void;
+  handleSuccessfulDrop?: (draggable: Draggable<T>) => void;
+}
+
+const { addDraggable, removeDraggable, findDropzone } = useDragAndDropState();
+const { x, y } = useMouse();
+
+export const useDrag = <T>(
+  dragOptions: DragOptions<T>,
+): [DragReturn<T>['init'], DragReturn<T>['draggable']] => {
+  // Set default options and merge with user-provided options
+  const defaultOptions: Partial<DragOptions<T>> = {
+    startDelay: 100,
+  };
+  const options = { ...defaultOptions, ...dragOptions };
+
+  // Refs for the draggable element and its clone
+  const elementRef = ref<HTMLElement | null>();
+  const clonedElement = ref<HTMLElement | null>();
+
+  // Init draggable state
+  const draggable: Draggable<T> = {
+    type: options.type,
+    element: elementRef,
+    enteredDropzone: ref<Dropzone>(),
+    isDragging: ref(false),
+    item: ref(options.item) as Ref<T>,
+  };
+
+  // Track mouse state
+  const { pressed } = useMousePressed({ target: elementRef });
+  const dragStartPosition = ref<Vector2D>({
+    x: 0,
+    y: 0,
+  });
+  let dragLongPressTimer: number | undefined = 0;
+
+  /* Watch for mouse press state changes to start or end drag */
+  watch(pressed, (_pressed) => (_pressed ? startDrag() : endDrag()));
+
+  /**
+   * Start the drag operation
+   */
+  function startDrag() {
+    const pressedElement = document.elementFromPoint(x.value, y.value)!;
+    const rect = pressedElement.getBoundingClientRect();
+
+    dragStartPosition.value = {
+      x: x.value - rect.x,
+      y: y.value - rect.y,
+    };
+
+    dragLongPressTimer = setTimeout(() => {
+      if (options.onDragStart?.(draggable) === false) return;
+
+      draggable.isDragging.value = true;
+
+      if (options.draggingClass) {
+        elementRef.value?.classList.add(options.draggingClass);
+      }
+
+      // Create and style cloned element
+      clonedElement.value = pressedElement.cloneNode(true) as HTMLElement;
+      if (options.draggingCloneClass) {
+        clonedElement.value.classList.add(options.draggingCloneClass);
+      }
+
+      clonedElement.value.style.cssText = `
+        width: ${rect.width}px;
+        height: ${rect.height}px;
+        position: fixed;
+        z-index: 999999;
+        display: none;
+        pointer-events: none;
+      `;
+
+      pressedElement.append(clonedElement.value);
+    }, options.startDelay);
+  }
+
+  /**
+   * End the drag operation
+   */
+  function endDrag() {
+    clearTimeout(dragLongPressTimer);
+
+    clonedElement.value?.remove();
+    clonedElement.value = null;
+
+    if (!draggable.isDragging.value) return;
+
+    draggable.isDragging.value = false;
+
+    options.onDropAttempt?.(draggable);
+
+    if (options.draggingClass) {
+      elementRef.value?.classList.remove(options.draggingClass);
+    }
+
+    if (!draggable.enteredDropzone.value) {
+      options.onFailedDrop?.(draggable);
+      return;
+    }
+
+    if (!draggable.enteredDropzone.value.drop?.(draggable)) {
+      options.onFailedDrop?.(draggable);
+      draggable.enteredDropzone.value = null;
+
+      return;
+    }
+
+    options.onSuccessfulDrop?.(draggable);
+    draggable.enteredDropzone.value = null;
+  }
+
+  /* Updated cloned element position and look for dropzones */
+  watch([x, y], () => {
+    if (!draggable.isDragging.value || !clonedElement.value) return;
+
+    clonedElement.value.style.display = '';
+    clonedElement.value.style.left = `${x.value - dragStartPosition.value.x}px`;
+    clonedElement.value.style.top = `${y.value - dragStartPosition.value.y}px`;
+
+    lookForDropzone();
+  });
+
+  /**
+   * Check if the cloned element is over a dropzone
+   * @returns
+   */
+  function lookForDropzone() {
+    const hoveredElement = document.elementFromPoint(x.value, y.value);
+    const dropzone = findDropzone((d) => d.element.value === hoveredElement);
+
+    // If we hovered another dropzone, it means that we leaved previous dropzone
+    if (
+      draggable.enteredDropzone.value &&
+      dropzone?.element !== draggable.enteredDropzone.value.element
+    ) {
+      draggable.enteredDropzone.value?.leave?.(draggable);
+    }
+
+    draggable.enteredDropzone.value = dropzone;
+
+    // We hovered non-dropzone element
+    if (!dropzone) return;
+
+    draggable.enteredDropzone.value?.enter?.(draggable);
+  }
+
+  // Add and remove draggable from the collection
+  onMounted(() => addDraggable(draggable));
+  onUnmounted(() => removeDraggable(draggable));
+
+  // Provide the function to init drag and the draggable state
+  return [
+    (el: HTMLElement) => {
+      elementRef.value = el;
+      return el;
+    },
+
+    draggable,
+  ];
+};

--- a/src/composable/drag-and-drop/useDragAndDropState.ts
+++ b/src/composable/drag-and-drop/useDragAndDropState.ts
@@ -1,0 +1,54 @@
+import { readonly, type DeepReadonly, type UnwrapNestedRefs } from 'vue';
+import type { Draggable } from './useDrag';
+import type { Dropzone } from './useDrop';
+
+interface DragAndDropStateReturn {
+  draggables: DeepReadonly<UnwrapNestedRefs<Draggable<Object>[]>>;
+  dropzones: DeepReadonly<UnwrapNestedRefs<Dropzone[]>>;
+  addDraggable: <T>(draggable: Draggable<T>) => void;
+  removeDraggable: <T>(draggable: Draggable<T>) => void;
+  addDropzone: (dropzone: Dropzone) => void;
+  removeDropzone: (dropzone: Dropzone) => void;
+  findDropzone: (predicate: (d: Dropzone) => {}) => Dropzone | undefined;
+}
+
+// The Draggable/Dropzone collections
+let draggables: Draggable<any>[] = [];
+let dropzones: Dropzone[] = [];
+
+export const useDragAndDropState = (): DragAndDropStateReturn => {
+  function addDraggable<T>(draggable: Draggable<T>) {
+    draggables.push(draggable);
+  }
+
+  function removeDraggable<T>(draggable: Draggable<T>) {
+    draggables = draggables.filter((d) => d !== draggable);
+  }
+
+  function addDropzone(dropzone: Dropzone) {
+    dropzones.push(dropzone);
+  }
+
+  function removeDropzone(dropzone: Dropzone) {
+    dropzones = dropzones.filter((d) => d !== dropzone);
+  }
+
+  /**
+   * Try to find a dropzone with predicate
+   * @param predicate
+   * @returns
+   */
+  function findDropzone(predicate: (d: Dropzone) => {}): Dropzone | undefined {
+    return dropzones.find(predicate);
+  }
+
+  return {
+    draggables: readonly(draggables),
+    dropzones: readonly(dropzones),
+    addDraggable,
+    removeDraggable,
+    addDropzone,
+    removeDropzone,
+    findDropzone,
+  };
+};

--- a/src/composable/drag-and-drop/useDrop.ts
+++ b/src/composable/drag-and-drop/useDrop.ts
@@ -1,0 +1,182 @@
+import { onMounted, onUnmounted, ref, type Ref } from 'vue';
+
+import { useDragAndDropState } from './useDragAndDropState';
+import type { Draggable } from './useDrag';
+
+/**
+ * Dropzone state
+ */
+export interface Dropzone {
+  /**
+   * What type of draggable should be accepted
+   */
+  accepts: string;
+
+  /**
+   * The reactive reference holding the value of dropzone element
+   */
+  element: Ref<HTMLElement | null | undefined>;
+
+  /**
+   * Function to enter dropzone with draggable
+   * @param draggable
+   * @returns
+   */
+  enter: (draggable: Draggable<any>) => void;
+
+  /**
+   * Function to leave dropzone with draggable
+   * @param draggable
+   * @returns
+   */
+  leave: (draggable: Draggable<any>) => void;
+
+  /**
+   * Function to check if draggable can be dropped in dropzone
+   * @param draggable
+   * @returns
+   */
+  canDrop: (draggable: Draggable<any>) => boolean;
+
+  /**
+   * Function to drop draggable into dropzone
+   * @param draggable
+   * @returns Return true - if drop is successful / false - if drop was failed
+   */
+  drop: (draggable: Draggable<any>) => boolean;
+}
+
+interface DropOptions {
+  /**
+   * What type of draggable should be allowed to drop in the dropzone
+   */
+  accepts: string;
+
+  /**
+   * Optional class name to be added to the dropzone element while any valid draggable is over the dropzone
+   */
+  dropZoneClass?: string;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was made
+   * @param draggable - The draggable state that tries to drop to a dropzone
+   * @returns
+   */
+  onDropAttempt?: (draggable: Draggable<any>) => void;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was failed
+   * @param draggable - The draggable state that failed to drop to a dropzone
+   * @returns
+   */
+  onFailedDrop?: (draggable: Draggable<any>) => void;
+
+  /**
+   * Optional callback function that is triggered when a drop attempt was successful
+   * @param draggable - The draggable state that dropped to a dropzone
+   * @returns
+   */
+  onSuccessfulDrop?: (draggable: Draggable<any>) => void;
+}
+
+interface DropReturn {
+  /**
+   * Function to be used with an HTML element's `ref` attribute to give the element drop functionality
+   * @example
+   * const [initDrop, dropzone] = useDrop<Item>({...})
+   * <div :ref="initDrop"></div>
+   *
+   * @param el - The HTML element that should have drop functionality applied
+   *
+   * @returns The same HTML element. It useful if you want to give the element drag/drop functionality simultaneously
+   * @example
+   * const [initDrag, draggable] = useDrag<Item>({...})
+   * const [initDrop, dropzone] = useDrop<Item>({...})
+   * <div :ref="(node) => initDrop(initDrag(node))"></div>
+   */
+  init: (el: any) => {};
+
+  /**
+   * The state of the created dropzone in `useDrop` composable
+   */
+  dropzone: Dropzone;
+}
+
+/**
+ * Handlers to use in defineProps' types
+ * @example
+ * const props = defineProps<{
+ *   cell: GridCell;
+ *   dropzone?: DropzoneEventHandlers<GridCell>;
+ * }>();
+ *
+ * ...
+ * props.dropzone?.handleDragStart?.(draggable);
+ * ...
+ */
+export interface DropzoneEventHandlers<T> {
+  handleDropAttempt?: (draggable: Draggable<T>) => void;
+  handleFailedDrop?: (draggable: Draggable<T>) => void;
+  handleSuccessfulDrop?: (draggable: Draggable<T>) => void;
+}
+
+const { addDropzone, removeDropzone } = useDragAndDropState();
+
+export const useDrop = (dropOptions: DropOptions): [DropReturn['init'], DropReturn['dropzone']] => {
+  // Set default option and merge with user-provided options
+  const defaultOptions: Partial<DropOptions> = {};
+  const options = { ...defaultOptions, ...dropOptions };
+
+  // Ref for the dropzone element
+  const elementRef = ref<HTMLElement | null>();
+
+  // Init dropzone state
+  const dropzone: Dropzone = {
+    accepts: options.accepts,
+    element: elementRef,
+
+    enter(draggable) {
+      if (this.canDrop(draggable) && options.dropZoneClass) {
+        dropzone.element.value?.classList.add(options.dropZoneClass);
+      }
+    },
+
+    leave(draggable) {
+      if (options.dropZoneClass) {
+        dropzone.element.value?.classList.remove(options.dropZoneClass);
+      }
+    },
+
+    canDrop(draggable) {
+      return draggable.type === dropzone.accepts;
+    },
+
+    drop(draggable) {
+      this.leave(draggable);
+
+      options.onDropAttempt?.(draggable);
+
+      if (!this.canDrop(draggable)) {
+        options.onFailedDrop?.(draggable);
+        return false;
+      }
+
+      options.onSuccessfulDrop?.(draggable);
+      return true;
+    },
+  };
+
+  // Add and remove dropzone from the collection
+  onMounted(() => addDropzone(dropzone));
+  onUnmounted(() => removeDropzone(dropzone));
+
+  // Provide the function to init drop and the dropzone state
+  return [
+    (el: HTMLElement) => {
+      elementRef.value = el;
+      return el;
+    },
+
+    dropzone,
+  ];
+};

--- a/src/types/vector-2d.ts
+++ b/src/types/vector-2d.ts
@@ -1,0 +1,4 @@
+export type Vector2D = {
+  x: number;
+  y: number;
+};


### PR DESCRIPTION
This update introduces:
  - Dropping "@formkit/drag-and-drop".
  - Implementation of **"Yet Another Vue Drag-and-Drop (YAVDnD)"** - a new Drag and Drop implementation without relying on horrible native HTML - (more info in _**/composable/drag-and-drop/README.md**_).
  - Integration **YAVDnD** into **InventoryGrid**, **InventoryGridCell** components